### PR TITLE
test: fix an example

### DIFF
--- a/examples/create_user.go
+++ b/examples/create_user.go
@@ -9,8 +9,8 @@ import (
 type (
 	// Client is a simple API client
 	Client struct {
-		ClientFn func() (*http.Client, error)
-		Token    string
+		HTTPClient *http.Client
+		Token      string
 	}
 
 	// User is a User
@@ -23,13 +23,9 @@ type (
 
 // CreateUser create a user.
 func (client *Client) CreateUser(user *User) (*User, *http.Response, error) {
-	c := &http.Client{}
-	if client.ClientFn != nil {
-		var err error
-		c, err = client.ClientFn()
-		if err != nil {
-			return nil, nil, err
-		}
+	c := client.HTTPClient
+	if c == nil {
+		c = http.DefaultClient
 	}
 	b, err := json.Marshal(user)
 	if err != nil {

--- a/examples/create_user_test.go
+++ b/examples/create_user_test.go
@@ -12,45 +12,43 @@ func TestClient_CreateUser(t *testing.T) {
 	token := "XXXXX"
 	client := &Client{
 		Token: token,
-		ClientFn: func() (*http.Client, error) {
-			return &http.Client{
-				Transport: &fagott.Transport{
-					T: t,
-					Services: []fagott.Service{
-						{
-							Endpoint: "http://example.com",
-							Routes: []fagott.Route{
-								{
-									Name: "create a user",
-									Matcher: &fagott.Matcher{
-										Method: "POST",
-										Path:   "/users",
-									},
-									Tester: &fagott.Tester{
-										BodyJSONString: `{
+		HTTPClient: &http.Client{
+			Transport: &fagott.Transport{
+				T: t,
+				Services: []fagott.Service{
+					{
+						Endpoint: "http://example.com",
+						Routes: []fagott.Route{
+							{
+								Name: "create a user",
+								Matcher: &fagott.Matcher{
+									Method: "POST",
+									Path:   "/users",
+								},
+								Tester: &fagott.Tester{
+									BodyJSONString: `{
 										  "name": "foo",
 										  "email": "foo@example.com"
 										}`,
-										Header: http.Header{
-											"Authorization": []string{"token " + token},
-										},
+									Header: http.Header{
+										"Authorization": []string{"token " + token},
 									},
-									Response: &fagott.Response{
-										Base: http.Response{
-											StatusCode: 201,
-										},
-										BodyString: `{
+								},
+								Response: &fagott.Response{
+									Base: http.Response{
+										StatusCode: 201,
+									},
+									BodyString: `{
 										  "id": 10,
 										  "name": "foo",
 										  "email": "foo@example.com"
 										}`,
-									},
 								},
 							},
 						},
 					},
 				},
-			}, nil
+			},
 		},
 	}
 	user, _, err := client.CreateUser(&User{


### PR DESCRIPTION
Fix to reuse *http.Client.

https://golang.org/pkg/net/http/#Client

> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed.
> Clients are safe for concurrent use by multiple goroutines.