### PR TITLE
build: fix npm security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@commitlint/cli": "^7.2.1",
     "@commitlint/config-angular": "^7.1.2",
     "husky": "^1.1.3",
-    "lodash.template": ">=4.5.0"
+    "lodash.template": ">=4.5.0",
+    "lodash": ">=4.17.13"
   }
 }


### PR DESCRIPTION
> Upgrade lodash to version 4.17.13 or later.